### PR TITLE
Silence some compiler warnings

### DIFF
--- a/include/mscomp/internal.h
+++ b/include/mscomp/internal.h
@@ -25,11 +25,17 @@
 #define MSCOMP_INTERNAL_H
 
 // For MSVC
-#define _CRT_SECURE_NO_WARNINGS
-#define _CRT_NON_CONFORMING_SWPRINTFS
+#if !defined(_CRT_SECURE_NO_WARNINGS)
+	#define _CRT_SECURE_NO_WARNINGS
+#endif
+#if !defined(_CRT_NON_CONFORMING_SWPRINTFS)
+	#define _CRT_NON_CONFORMING_SWPRINTFS
+#endif
 
 // For GCC
-#define __STDC_LIMIT_MACROS
+#if !defined(__STDC_LIMIT_MACROS)
+	#define __STDC_LIMIT_MACROS
+#endif
 
 #include "general.h"
 #include <stddef.h>

--- a/src/xpress_huff_compress.cpp
+++ b/src/xpress_huff_compress.cpp
@@ -90,7 +90,7 @@ static size_t xh_compress_lz77(const_bytes in, int32_t /* * */ in_len, const_byt
 			if (rem >= 3 && (len = d->Find(in, &off)) >= 3)
 			{
 				// TODO: allow len > rem (chunk-spanning matches)
-				if (len > rem) { len = rem; }
+				if (len > (uint32_t)rem) { len = rem; }
 				in += len; rem -= len;
 				
 				//d->Add(in + 1, len - 1);


### PR DESCRIPTION
I'm trying to get Squash to compile without warnings on MSVC (quixdb/squash#155), and these are the ones ms-compress triggers.  I can disable them in Squash, but I figured I might as well just fix them here instead.  Build log with warnings is at https://ci.appveyor.com/project/quixdb/squash/build/0.8.0-165/job/xyie0nltj4gqv323#L2092