### PR TITLE
Check that size is not 0 before calling memcpy.

### DIFF
--- a/include/mscomp/internal.h
+++ b/include/mscomp/internal.h
@@ -510,10 +510,12 @@ typedef const_byte* RESTRICT const_rest_bytes;
 		for (;;) \
 		{ \
 			const size_t copy = MIN(state->in_needed, stream->in_avail); \
-			memcpy(state->in + state->in_avail, stream->in, copy); \
-			state->in_avail  += copy; \
-			state->in_needed -= copy; \
-			ADVANCE_IN(stream, copy); \
+			if (copy != 0) { \
+				memcpy(state->in + state->in_avail, stream->in, copy); \
+				state->in_avail  += copy; \
+				state->in_needed -= copy; \
+				ADVANCE_IN(stream, copy); \
+			} \
 			OP \
 			break; \
 		} \


### PR DESCRIPTION
Without this I get "ms-compress/src/lznt1_compress.cpp:159:2: runtime error: null pointer passed as argument 2, which is declared to never be null" when compiling with ubsan.